### PR TITLE
Fixed issue #5

### DIFF
--- a/flowmeter/features.py
+++ b/flowmeter/features.py
@@ -278,9 +278,9 @@ class Features:
 			
         """
         
-        bwd = df["src"].unique().tolist()[1]
-        bwd_df = df.loc[df["src"]==bwd]
-        return bwd_df["size"].sum()
+        src = self.get_dst_ip
+        src_df = df.loc[df["src"]==src]
+        return src_df["size"].sum()
 	
     def get_total_forward_packets(self, df):
     


### PR DESCRIPTION
The early version of get_total_len_backward_packets() 
didn't implement the helper method for finding the 
destination IP and no multicast flag was set. 
Reimplemented this method to conform with 
standard flow of getting the destination IP.